### PR TITLE
Use wildcard for module includes

### DIFF
--- a/Sming/Libraries/WS2812/WS2812.h
+++ b/Sming/Libraries/WS2812/WS2812.h
@@ -1,7 +1,7 @@
 #ifndef WS2812_h
 #define WS2812_h
 
-#include <SmingCore/SmingCore.h>
+#include "../../SmingCore/SmingCore.h"
 
 // Byte triples in the buffer are interpreted as R G B values and sent to the hardware as G R B.
 int ICACHE_FLASH_ATTR ws2812_writergb(uint8_t gpio, char *buffer, size_t length);

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -90,7 +90,7 @@ FW_BASE		= out/firmware
 TARGET		= app
 
 # which modules (subdirectories) of the project to include in compiling
-MODULES		= system system/helpers Wiring SmingCore SmingCore/Network SmingCore/Platform Services/SpifFS Services/ArduinoJson Services/WebHelpers Services/DateTime appinit Libraries/DHT Libraries/LiquidCrystal Libraries/LCD5110 Libraries/Bounce Libraries/Adafruit_GFX Libraries/TFT_ILI9163C Libraries/Adafruit_SSD1306 Libraries/OneWire Libraries/Ultrasonic
+MODULES		= system system/helpers Wiring SmingCore appinit $(filter %/, $(wildcard SmingCore/*/)) $(filter %/, $(wildcard Services/*/)) $(filter %/, $(wildcard Libraries/*/))
 EXTRA_INCDIR    = include include  system/include Wiring Libraries SmingCore $(SDK_BASE)/../include
 
 # libraries used in this project, mainly provided by the SDK


### PR DESCRIPTION
Fixes to allow us to use wildcards to include Libraries, Services and SmingCore directories.
